### PR TITLE
Mismatch between Modal.dialog and hideSiblings parameters

### DIFF
--- a/src/utils/manageAriaHidden.js
+++ b/src/utils/manageAriaHidden.js
@@ -21,10 +21,10 @@ export function ariaHidden(show, node) {
   }
 }
 
-export function hideSiblings(container, { root, backdrop }) {
-  siblings(container, [root, backdrop], node => ariaHidden(true, node));
+export function hideSiblings(container, { dialog, backdrop }) {
+  siblings(container, [dialog, backdrop], node => ariaHidden(true, node));
 }
 
-export function showSiblings(container, { root, backdrop }) {
-  siblings(container, [root, backdrop], node => ariaHidden(false, node));
+export function showSiblings(container, { dialog, backdrop }) {
+  siblings(container, [dialog, backdrop], node => ariaHidden(false, node));
 }


### PR DESCRIPTION
Fixes the issue raised here: https://github.com/react-bootstrap/react-overlays/issues/240

The modal component contains refs to `dialog` and `backdrop` https://github.com/omniverse/react-overlays/blob/master/src/Modal.js#L309-L315
not `root` and `backdrop` as destructured in manageAriaHidden https://github.com/omniverse/react-overlays/blob/master/src/Modal.js#L309-L315

So the aria-hidden="true" attribute was getting applied to the dialog itself and breaking screen readers, accessibility features, etc.